### PR TITLE
Update sensor.py with missing `unit_class`

### DIFF
--- a/custom_components/leakbot/sensor.py
+++ b/custom_components/leakbot/sensor.py
@@ -271,5 +271,6 @@ class LeakbotWaterHistorySensor(LeakbotEntity, SensorEntity):
                 source="recorder",
                 statistic_id=statistic_id,
                 unit_of_measurement=self.unit_of_measurement,
+                unit_class=None,
             )
             async_import_statistics(self.hass, new_stats_meta, new_stats)


### PR DESCRIPTION
Fixes missing unit_class. Future requirement

`
Detected that custom integration 'leakbot' doesn't specify unit_class when calling async_import_statistics at custom_components/leakbot/sensor.py, line 275: async_import_statistics(self.hass, new_stats_meta, new_stats). This will stop working in Home Assistant 2026.11, please create a bug report at https://github.com/sHedC/homeassistant-leakbot/issues
`